### PR TITLE
WIP: pinot-client-go: change unmarshal logistic

### DIFF
--- a/pinot-client-go/jsonAsyncHTTPClientTransport.go
+++ b/pinot-client-go/jsonAsyncHTTPClientTransport.go
@@ -48,7 +48,9 @@ func (t jsonAsyncHTTPClientTransport) execute(brokerAddress string, query *Reque
 			return nil, err
 		}
 		var brokerResponse BrokerResponse
-		err = json.Unmarshal(bodyBytes, &brokerResponse)
+		d := json.NewDecoder(bytes.NewBuffer(bodyBytes))
+		d.UseNumber()
+		err = d.Decode(&brokerResponse)
 		if err != nil {
 			log.Error("Unable to unmarshal json response to a brokerResponse structure. ", err)
 			return nil, err


### PR DESCRIPTION
What problem does this PR solve?
Issue Number: close #1 

Problem Summary: Unmarshal int with float64 and show as scientific notation.

What is changed and how it works?
What's Changed: Use number for store origin data.

How it Works: don't base on float64 to unmarshal bytes.

Release note
No release note